### PR TITLE
chore: add gasPriceStep to config

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -41,7 +41,7 @@ export const EmbedChainInfos: ChainInfo[] = [
     coinType: 118,
     features: [],
     gasPriceStep: {
-      low: 5000000000,
+      low: 0,
       average: 5000000000,
       high: 6250000000,
     },
@@ -83,7 +83,7 @@ export const EmbedChainInfos: ChainInfo[] = [
     coinType: 118,
     features: [],
     gasPriceStep: {
-      low: 5000000000,
+      low: 0,
       average: 5000000000,
       high: 6250000000,
     },
@@ -120,7 +120,7 @@ export const EmbedChainInfos: ChainInfo[] = [
     coinType: 118,
     features: [],
     gasPriceStep: {
-      low: 5000000000,
+      low: 0,
       average: 5000000000,
       high: 6250000000,
     },

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -40,6 +40,11 @@ export const EmbedChainInfos: ChainInfo[] = [
     ],
     coinType: 118,
     features: [],
+    gasPriceStep: {
+      low: 5000000000,
+      average: 5000000000,
+      high: 6250000000,
+    },
   },
   {
     rpc: "https://rpc-andromeda.fetch.ai",
@@ -114,6 +119,11 @@ export const EmbedChainInfos: ChainInfo[] = [
     ],
     coinType: 118,
     features: [],
+    gasPriceStep: {
+      low: 5000000000,
+      average: 5000000000,
+      high: 6250000000,
+    },
   },
 ];
 

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -77,6 +77,11 @@ export const EmbedChainInfos: ChainInfo[] = [
     ],
     coinType: 118,
     features: [],
+    gasPriceStep: {
+      low: 5000000000,
+      average: 5000000000,
+      high: 6250000000,
+    },
   },
   {
     rpc: "https://rpc-stargateworld.fetch.ai",


### PR DESCRIPTION
### Degrees of freedom
#### `gasPriceStep` in keplr config
We can set arbitrary values for "low", "average", and "high" gas prices via gasPriceStep on a **per chain/network basis**.
If we don't, arbitrary defaults will be used ([`DefaultGasPriceStep`](https://github.com/fetchai/keplr-extension/blob/master/packages/hooks/src/tx/types.ts#L66)). It's worth noting that this configuration will have an effect on any transactions that the ledger-explorer generates.

#### Default gas amount
We can set the gas amount to influence the calculated fee (fee = gas amount * gas price) ([keplr-extension/packages/hooks/src/tx/fee.ts:163](https://github.com/fetchai/keplr-extension/blob/master/packages/hooks/src/tx/fee.ts#L163)). This change would happen in the [ledger-explorer's API](https://github.com/fetchai/ledger-explorer/tree/master/src/api).

### Limitations
#### Setting fees in transaction-generating calls
@cosmjs/stargate supports setting a fee in calls to members which broadcast transactions (i.e. [`delegateTokens`](https://github.com/cosmos/cosmjs/blob/main/packages/stargate/src/signingstargateclient.ts#L225)) that it then sends to the signer, keplr, in this case. Unfortunately, the cosmjs/amino `OfflineAminoSigner` interface's `signAmino` method does not currently support any arguments which could pass additional options to keplr's `signAmino` implementation. This is unfortunate because the keplr UI ignores the fee in the transaction data unless `preferNoSetFee` of the `KeplrSigningOptions` argument is true (see [packages/extension/src/pages/sign/index.ts:96](https://github.com/fetchai/keplr-extension/blob/master/packages/extension/src/pages/sign/index.tsx#L96)).

#### Setting default "fee type"
We cannot set which "fee type" (i.e. low, avg. high) is selected in the keplr UI without additional modifications to keplr.
[`feeConfig.setFeeType()`](https://github.com/fetchai/keplr-extension/blob/master/packages/hooks/src/tx/fee.ts#L79) is called with a string constant "average" in [fee-buttons.tsx](https://github.com/fetchai/keplr-extension/blob/master/packages/extension/src/pages/sign/index.tsx#L63) component which renders the "fee type" button group.
We could either:
- modify fee-buttons.tsx to pass a variable instead, this begs the question: "What's the most appropriate way to get that variable into scope?"
  - For consistency it probably makes sense for this to be a configuration value with a reasonable default; in this case, using "average" probably makes sense.
- call setFeeType ourselves on the config at some point. The config is initially created with a call to useFeeConfig ([sign/index:000]()).

### Other considerations
Changes to the `gasPriceStep` will require a releasing an update of our keplr-extension fork in order to take effect (see [Chrome webstore update docs](https://developer.chrome.com/docs/webstore/update/)). 