### PR TITLE
fix: fee unit prefixes (ECO-930)

### DIFF
--- a/packages/unit/src/coin-pretty.spec.ts
+++ b/packages/unit/src/coin-pretty.spec.ts
@@ -223,3 +223,71 @@ describe("Test CoinPretty", () => {
     });
   });
 });
+
+describe("#toMetricPrefix", function () {
+  describe("should return the correct unit prefix", () => {
+    const padRightZero = (str: string, length: number): string => {
+      return str + Array(length).fill("0").join("");
+    };
+
+    const testCoinPretty = (
+      significantDigits: string,
+      zeroPadLength: number
+    ): CoinPretty | null => {
+      if (zeroPadLength < 0) return null;
+
+      return new CoinPretty(
+        {
+          coinDenom: "ATOM",
+          coinMinimalDenom: "attoatom",
+          coinDecimals: 18,
+        },
+        new Int(padRightZero(significantDigits, zeroPadLength))
+      );
+    };
+
+    const metricPrefixes = ["atto", "femto", "pico", "nano", "micro", "milli"];
+    const scenarios = (prefix: string, index: number) => {
+      const smallerPrefix = metricPrefixes[index - 1];
+      return [
+        {
+          name: "one significant digit",
+          input: testCoinPretty("1", index * 3),
+          expectedAmount: `1 ${prefix} ATOM`,
+        },
+        {
+          name: "two significant digits",
+          input: testCoinPretty("14", index * 3 - 1),
+          expectedAmount: `1.4 ${prefix} ATOM`,
+        },
+        {
+          name: "three significant digits",
+          input: testCoinPretty("125", index * 3 - 2),
+          expectedAmount: `1.25 ${prefix} ATOM`,
+        },
+        {
+          name: "four significant digits",
+          input: testCoinPretty("1725", index * 3 - 3),
+          expectedAmount: `1725 ${smallerPrefix} ATOM`,
+        },
+      ];
+    };
+
+    metricPrefixes.forEach((prefix: string, i: number) => {
+      describe(prefix, () => {
+        scenarios(prefix, i).forEach((scenario: Record<string, any>) => {
+          if (scenario.input === null)
+            pending(
+              "prefix unit is minimal denomination in fractional amount scenario"
+            );
+
+          it(scenario.name, () => {
+            expect(scenario.input.toMetricPrefix()).toBe(
+              scenario.expectedAmount
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/unit/src/coin-pretty.ts
+++ b/packages/unit/src/coin-pretty.ts
@@ -252,10 +252,15 @@ export class CoinPretty {
   }
 
   toMetricPrefix(): string {
-    const [, afterPoint] = this.intPretty.toString().split(".");
+    let [, afterPoint] = this.intPretty.toString().split(".");
 
     if (!afterPoint) {
       return this.intPretty.toString();
+    }
+    for (let i = afterPoint.length; i > 0; i--) {
+      if (afterPoint.endsWith("0")) {
+        afterPoint = afterPoint.slice(0, i - 1);
+      }
     }
 
     let denom = this.denom;
@@ -275,7 +280,7 @@ export class CoinPretty {
 
     const { remainder, prefix } = toMetric(afterPoint.length);
     const numberPart = remainder
-      ? Number(afterPoint) * Math.pow(10, remainder)
+      ? Number(afterPoint) / Math.pow(10, remainder)
       : Number(afterPoint);
     const prefixPart = prefix ? ` ${prefix}` : "";
 


### PR DESCRIPTION
### Changes
- adds regression test for `CoinPretty#toMetricPrefix`
- fixes trailing zeros in `afterPoint` throwing off `remainder`
- fixes sign in exponentiation operation when calculating `numberPart`

#### Before

![Screenshot from 2022-01-20 11-56-57](https://user-images.githubusercontent.com/600733/154520094-8ff7fb3f-4174-4610-ad7b-d318c29b9cd8.png)

#### After

![image](https://user-images.githubusercontent.com/600733/154519308-2d145189-4c82-4f88-b89a-3d44e1b1464c.png)
