### PR TITLE
feat: add address copy icon

### DIFF
--- a/packages/extension/src/components/address/index.tsx
+++ b/packages/extension/src/components/address/index.tsx
@@ -8,6 +8,7 @@ export interface AddressProps {
   children: string;
   tooltipFontSize?: string;
   tooltipAddress?: string;
+  iconClass?: string;
 
   lineBreakBeforePrefix?: boolean;
 }
@@ -34,6 +35,8 @@ export class Address extends React.Component<AddressProps> {
       ? this.props.tooltipAddress
       : children;
 
+    const iconClass = [this.props.iconClass, "pr-2"].join(" ");
+
     return (
       <ToolTip
         trigger="hover"
@@ -55,6 +58,7 @@ export class Address extends React.Component<AddressProps> {
           </div>
         }
       >
+        {this.props.iconClass ? <i className={iconClass} /> : ""}
         {Bech32Address.shortenAddress(children, this.props.maxCharacters)}
       </ToolTip>
     );

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -59,7 +59,11 @@ export const AccountView: FunctionComponent = observer(() => {
           className={styleAccount.address}
           onClick={() => copyAddress(accountInfo.bech32Address)}
         >
-          <Address maxCharacters={22} lineBreakBeforePrefix={false}>
+          <Address
+            maxCharacters={22}
+            lineBreakBeforePrefix={false}
+            iconClass="fas fa-copy"
+          >
             {accountInfo.walletStatus === WalletStatus.Loaded &&
             accountInfo.bech32Address
               ? accountInfo.bech32Address


### PR DESCRIPTION
### Changes
- Adds copy icon in front of the address component


| Before | After |
| --- | --- |
| ![eco-1100-before](https://user-images.githubusercontent.com/600733/158824922-b05e84b7-8e20-4375-9778-c40fe742ab11.png) | ![eco-1100-after](https://user-images.githubusercontent.com/600733/158824959-f8392c10-9db8-4b2c-84ba-5572c36553ea.png) |

 