### PR TITLE
fix: balance chart (ECO-1079)

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -55,7 +55,6 @@ export const EmbedChainInfos: ChainInfo[] = [
       coinDenom: "TESTFET",
       coinMinimalDenom: "atestfet",
       coinDecimals: 18,
-      coinGeckoId: "fetch-ai",
     },
     bip44: {
       coinType: 118,

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -24,6 +24,7 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "FET",
         coinMinimalDenom: "afet",
         coinDecimals: 18,
+        coinGeckoId: "fetch-ai",
       },
       {
         coinDenom: "MOBX",
@@ -36,6 +37,7 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "FET",
         coinMinimalDenom: "afet",
         coinDecimals: 18,
+        coinGeckoId: "fetch-ai",
       },
     ],
     coinType: 118,


### PR DESCRIPTION
### Changes:
- Remove `coinGeckoId` for testnet (Capricorn) currency configs
- Ensure `coinGeckoId` is present for all supported (i.e. by coingecko.com) mainnet currency configs

`coinGeckoId` must be present **consistently** accross any given network's currency config objects for any given currency. Multiple queries are required to calculate the values for the chart, some use different currency configs (e.g. staking vs balance).

| Before | After |
| --- | --- |
| ![keplr-balance-chart-wrong](https://user-images.githubusercontent.com/600733/158977992-29493742-533b-42f5-920a-f790a59df78c.png)| ![keplr-balance-chart](https://user-images.githubusercontent.com/600733/158978010-749c65b0-a497-496f-b63e-b2dd240a191c.png) |

