### PR TITLE
fix: update github link (ECO-1308)

### DIFF
--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Fetch.ai Network Wallet",
   "description": "The Fetch.ai network wallet, powered by Keplr, for interacting with an agent based world",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "icons": {
     "16": "assets/icon-16.png",
     "48": "assets/icon-48.png",

--- a/packages/extension/src/pages/main/menu.tsx
+++ b/packages/extension/src/pages/main/menu.tsx
@@ -78,7 +78,7 @@ export const Menu: FunctionComponent = observer(() => {
       <div className={styleMenu.footer}>
         <a
           className={styleMenu.inner}
-          href="https://github.com/everett-protocol/keplr-extension"
+          href="https://github.com/fetchai/keplr-extension"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
### Changes
- updates the link at the bottom of the menu with text "Check it out on GitHub":

![image](https://user-images.githubusercontent.com/600733/167570057-79644b98-cf22-4179-8aa0-89c32a219e9d.png)
