### PR TITLE
fix(mobile): prevent transaction hash clipping (#538)

### DIFF
--- a/packages/mobile/src/screens/activity/activity-details/activity-row.tsx
+++ b/packages/mobile/src/screens/activity/activity-details/activity-row.tsx
@@ -101,7 +101,13 @@ export const DetailRow = ({
           </View>
         )}
         <Text
-          style={style.flatten(["color-gray-400", "text-right"]) as ViewStyle}
+          style={
+            style.flatten([
+              "color-gray-400",
+              "text-right",
+              "flex-shrink-1",
+            ]) as ViewStyle
+          }
         >
           {value}
         </Text>


### PR DESCRIPTION
## Proposed Changes

Fixes #538. The transaction hash displayed on the mobile transaction details screen can be clipped when the available width is limited, particularly on iOS. The hash is already intentionally truncated using `formatToTruncated()`, but the resulting value can still overflow the available space in the `DetailRow` because the `Text` component was not configured to shrink within its parent row. This change adds the existing `flex-shrink-1` style to the transaction detail `Text` component in `packages/mobile/src/screens/activity/activity-details/activity-row.tsx`, allowing the displayed hash/value to shrink within the available width instead of being clipped. The change is intentionally minimal and does not modify transaction hash formatting, copy-to-clipboard functionality, transaction data handling, explorer URL generation, or the existing component structure.

## Linked Issues

Fixes #538

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x ] I have read the CONTRIBUTING guide
- [ x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments

The change was kept intentionally small because this is a layout-only issue. Validation performed: ESLint passed with 0 errors, Prettier passed, and `git diff --check` passed. The TypeScript typecheck was also run, but the repository currently reports existing unrelated TypeScript errors outside the modified file. iOS simulator/device testing was not performed locally because the development environment is Windows/WSL. The fix reuses the existing `flex-shrink-1` styling convention already present in the mobile codebase.